### PR TITLE
move prefix to .env

### DIFF
--- a/fictionsuit/bot.py
+++ b/fictionsuit/bot.py
@@ -13,7 +13,7 @@ class Bot(commands.Bot):
         self,
         system_msg=prompts.SYSTEM_MSG,
         stats_ui=True,
-        command_prefix=prompts.COMMAND_PREFIX,
+        command_prefix=config.COMMAND_PREFIX,
         mode="chat",
         intents=discord.Intents.default()
     ):

--- a/fictionsuit/config.py
+++ b/fictionsuit/config.py
@@ -9,3 +9,5 @@ PROD_TOKEN = os.environ["DISCORD_PROD_TOKEN"]
 SERVER = os.environ["SERVER"]
 OA_MODEL = "gpt-3.5-turbo-0301"
 openai.api_key = os.environ["OPENAI_API_KEY"]
+
+COMMAND_PREFIX = os.environ["COMMAND_PREFIX"] if "COMMAND_PREFIX" in os.environ else "chat "

--- a/fictionsuit/prompts.py
+++ b/fictionsuit/prompts.py
@@ -1,2 +1,1 @@
-COMMAND_PREFIX = "chat"
 SYSTEM_MSG = "You are a helpful assistant. Your responses are ALWAYS 240 characters or less. You never respond over 240 characters."


### PR DESCRIPTION
This just makes it so you can set COMMAND_PREFIX in .env for different bots. Otherwise it should still default to "chat ".