### PR TITLE
Even more sweeping changes to the scripting system.

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,7 +1,6 @@
 from argparse import ArgumentParser
-import os
 
-from fictionsuit.commands import Chat, Debug, Research
+from fictionsuit.commands import Chat, Debug, Research, Text
 from fictionsuit.core import BasicCommandSystem, TextIOClient
 
 
@@ -14,30 +13,19 @@ def main():
         help='disables CLI prompt ("> "), welcome message, and exit message. ideal for piping files through cli.py.',
     )
     parser.add_argument(
-        "-p",
-        "--prefix",
-        help="defines the command prefix, which is the empty string by default.",
-    )
-    parser.add_argument(
         "-r",
         "--reactions",
         help="show a message when the system attempts to react to a user message.",
     )
     args = parser.parse_args()
 
-    prefix = ""
-
-    if args.prefix is not None:
-        prefix = args.prefix
-
-    command_groups = [Debug(), Research(), Chat()]
+    command_groups = [Debug(), Research(), Chat(), Text()]
 
     system = BasicCommandSystem(
         command_groups,
         respond_on_unrecognized=False,
         stats_ui=False,
         enable_scripting=True,
-        prefix=prefix,
     )
 
     client = TextIOClient(system, cli=not args.quiet, reactions=args.reactions)

--- a/fictionsuit-vscode-ext/fictionscript-syntax/.vscode/launch.json
+++ b/fictionsuit-vscode-ext/fictionscript-syntax/.vscode/launch.json
@@ -1,0 +1,17 @@
+// A launch configuration that launches the extension inside a new window
+// Use IntelliSense to learn about possible attributes.
+// Hover to view descriptions of existing attributes.
+// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+{
+	"version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Extension",
+            "type": "extensionHost",
+            "request": "launch",
+            "args": [
+                "--extensionDevelopmentPath=${workspaceFolder}"
+            ]
+        }
+    ]
+}

--- a/fictionsuit-vscode-ext/fictionscript-syntax/.vscodeignore
+++ b/fictionsuit-vscode-ext/fictionscript-syntax/.vscodeignore
@@ -1,0 +1,4 @@
+.vscode/**
+.vscode-test/**
+.gitignore
+vsc-extension-quickstart.md

--- a/fictionsuit-vscode-ext/fictionscript-syntax/CHANGELOG.md
+++ b/fictionsuit-vscode-ext/fictionscript-syntax/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Change Log
+
+All notable changes to the "fictionscript-syntax" extension will be documented in this file.
+
+Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
+
+## [Unreleased]
+
+- Initial release

--- a/fictionsuit-vscode-ext/fictionscript-syntax/README.md
+++ b/fictionsuit-vscode-ext/fictionscript-syntax/README.md
@@ -1,0 +1,65 @@
+# fictionscript-syntax README
+
+This is the README for your extension "fictionscript-syntax". After writing up a brief description, we recommend including the following sections.
+
+## Features
+
+Describe specific features of your extension including screenshots of your extension in action. Image paths are relative to this README file.
+
+For example if there is an image subfolder under your extension project workspace:
+
+\!\[feature X\]\(images/feature-x.png\)
+
+> Tip: Many popular extensions utilize animations. This is an excellent way to show off your extension! We recommend short, focused animations that are easy to follow.
+
+## Requirements
+
+If you have any requirements or dependencies, add a section describing those and how to install and configure them.
+
+## Extension Settings
+
+Include if your extension adds any VS Code settings through the `contributes.configuration` extension point.
+
+For example:
+
+This extension contributes the following settings:
+
+* `myExtension.enable`: Enable/disable this extension.
+* `myExtension.thing`: Set to `blah` to do something.
+
+## Known Issues
+
+Calling out known issues can help limit users opening duplicate issues against your extension.
+
+## Release Notes
+
+Users appreciate release notes as you update your extension.
+
+### 1.0.0
+
+Initial release of ...
+
+### 1.0.1
+
+Fixed issue #.
+
+### 1.1.0
+
+Added features X, Y, and Z.
+
+---
+
+## Working with Markdown
+
+You can author your README using Visual Studio Code. Here are some useful editor keyboard shortcuts:
+
+* Split the editor (`Cmd+\` on macOS or `Ctrl+\` on Windows and Linux).
+* Toggle preview (`Shift+Cmd+V` on macOS or `Shift+Ctrl+V` on Windows and Linux).
+* Press `Ctrl+Space` (Windows, Linux, macOS) to see a list of Markdown snippets.
+
+## For more information
+
+* [Visual Studio Code's Markdown Support](http://code.visualstudio.com/docs/languages/markdown)
+* [Markdown Syntax Reference](https://help.github.com/articles/markdown-basics/)
+
+**Enjoy!**

--- a/fictionsuit-vscode-ext/fictionscript-syntax/language-configuration.json
+++ b/fictionsuit-vscode-ext/fictionscript-syntax/language-configuration.json
@@ -1,0 +1,18 @@
+{
+    "comments": {
+        // symbol used for single line comment. Remove this entry if your language does not support line comments
+        "lineComment": "#",
+    },
+    // symbols used as brackets
+    "brackets": [
+        ["{", "}"],
+    ],
+    // symbols that are auto closed when typing
+    "autoClosingPairs": [
+        ["{", "}"],
+    ],
+    // symbols that can be used to surround a selection
+    "surroundingPairs": [
+        ["{", "}"],
+    ]
+}

--- a/fictionsuit-vscode-ext/fictionscript-syntax/package.json
+++ b/fictionsuit-vscode-ext/fictionscript-syntax/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "fictionscript-syntax",
+  "displayName": "FictionScript Syntax",
+  "description": "FictionScript Syntax Highlighting",
+  "version": "0.0.1",
+  "engines": {
+    "vscode": "^1.76.0"
+  },
+  "categories": [
+    "Programming Languages"
+  ],
+  "contributes": {
+    "languages": [{
+      "id": "fictionscript",
+      "aliases": ["FictionScript", "fictionscript"],
+      "extensions": [".fic"],
+      "configuration": "./language-configuration.json"
+    }],
+    "grammars": [{
+      "language": "fictionscript",
+      "scopeName": "source.fic",
+      "path": "./syntaxes/fictionscript.tmLanguage.json"
+    }]
+  }
+}

--- a/fictionsuit-vscode-ext/fictionscript-syntax/syntaxes/backup
+++ b/fictionsuit-vscode-ext/fictionscript-syntax/syntaxes/backup
@@ -1,0 +1,32 @@
+{
+	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+	"name": "FictionScript",
+	"patterns": [
+		{
+			"include": "#keywords"
+		},
+		{
+			"include": "#strings"
+		}
+	],
+	"repository": {
+		"keywords": {
+			"patterns": [{
+				"name": "keyword.control.fictionscript",
+				"match": "\\b(if|return|then|else|chat)\\b"
+			}]
+		},
+		"strings": {
+			"name": "string.quoted.double.fictionscript",
+			"begin": "\"",
+			"end": "\"",
+			"patterns": [
+				{
+					"name": "constant.character.escape.fictionscript",
+					"match": "\\\\."
+				}
+			]
+		}
+	},
+	"scopeName": "main.fic"
+}

--- a/fictionsuit-vscode-ext/fictionscript-syntax/syntaxes/fictionscript.tmLanguage.json
+++ b/fictionsuit-vscode-ext/fictionscript-syntax/syntaxes/fictionscript.tmLanguage.json
@@ -1,0 +1,212 @@
+{
+	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+	"name": "FictionScript",
+	"patterns": [
+		{
+			"include": "#comments"
+		},
+		{
+			"include": "#expression"
+		},
+		{
+			"include": "#keywords"
+		}
+	],
+	"repository": {
+		"expression": {
+			"patterns": [
+				{
+					"include": "#if_cond_then"
+				},
+				{
+					"include": "#setliteral"
+				},
+				{
+					"include": "#setexpr"
+				},
+				{
+					"include": "#chat"
+				}
+			]
+		},
+		"comments": {
+			"patterns": [{
+				"name": "comment.line.number-sign.fictionscript",
+				"match": "#.*$"
+			}]
+		},
+		"keywords": {
+			"patterns": [{
+				"name": "keyword.control.fictionscript",
+				"match": "\\b(return|chat|arg|args|load_fic|fails|fail|fic|var|scope|\\$FIC|\\$\\.FIC)\\b"
+			}]
+		},
+		"setliteral": {
+			"patterns": [
+				{
+					"name": "string.quoted.double.fictionscript",
+					"begin": "(\\||arg|var)(?:\\s*(.*?)\\s*(>))*?\\s*(.*?)\\s*(:=)",
+					"end": "$",
+					"beginCaptures": {
+						"1": {
+							"name": "constant.language.fictionscript"
+						},
+						"2": {
+							"name": "variable.name.fictionscript"
+						},
+						"3": {
+							"name": "constant.language.fictionscript"
+						},
+						"4": {
+							"name": "variable.name.fictionscript"
+						},
+						"5": {
+							"name": "constant.language.fictionscript"
+						}
+					},
+					"patterns": [
+						{
+							"name": "variable.name.fictionscript",
+							"match": "{.*?}"
+						},
+						{
+							"name": "constant.character.escape",
+							"match": "\\\\n"
+						},
+						{
+							"name": "markup.italic",
+							"match": "."
+						}
+					]
+				}
+			]
+		},
+		"setexpr": {
+			"patterns": [
+				{
+					"name": "meta.selector.fictionscript",
+					"begin": "(\\||arg|var)(?:\\s*(.*?)\\s*(>))*?\\s*(.*?)\\s*(=)",
+					"end": "$",
+					"beginCaptures": {
+						"1": {
+							"name": "constant.language.fictionscript"
+						},
+						"2": {
+							"name": "variable.name.fictionscript"
+						},
+						"3": {
+							"name": "constant.language.fictionscript"
+						},
+						"4": {
+							"name": "variable.name.fictionscript"
+						},
+						"5": {
+							"name": "constant.language.fictionscript"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#expression"
+						}
+					]
+				}
+			]
+		},
+		"if_cond_then": {
+			"patterns": [
+				{
+					"name": "meta.selector.fictionscript",
+					"begin": "\\s*(if)\\s+",
+					"end": "\\s+(then)\\s+",
+					"beginCaptures": {
+						"1": {
+							"name": "keyword.control.fictionscript"
+						}
+					},
+					"endCaptures": {
+						"1": {
+							"name": "keyword.control.fictionscript"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#expression"
+						}
+					]
+				}
+			]
+		},
+		"retrieve": {
+			"patterns": [
+				{
+					"name": "meta.selector.fictionscript",
+					"begin": "(\\||retrieve)(?:\\s*(.*?)\\s*(>))*\\s*(.+)\\s*(\\?)?\\s*",
+					"end": "$",
+					"beginCaptures": {
+						"1": {
+							"name": "constant.language.fictionscript"
+						},
+						"2": {
+							"name": "variable.name.fictionscript"
+						},
+						"3": {
+							"name": "constant.language.fictionscript"
+						},
+						"4": {
+							"name": "variable.name.fictionscript"
+						},
+						"5": {
+							"name": "constant.language.fictionscript"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#expression"
+						}
+					]
+				}
+			]
+		},
+		"chat": {
+			"patterns": [
+				{
+					"name": "string.quoted.double.fictionscript",
+					"begin": "(<)\\s*(?:(system|user|assistant)\\s*(@))?\\s*(.*?)\\s*(>)",
+					"end": "$",
+					"beginCaptures": {
+						"1": {
+							"name": "constant.language.fictionscript"
+						},
+						"2": {
+							"name": "keyword.control.fictionscript"
+						},
+						"3": {
+							"name": "constant.language.fictionscript"
+						},
+						"4": {
+							"name": "variable.name.fictionscript"
+						},
+						"5": {
+							"name": "constant.language.fictionscript"
+						}
+					},
+					"patterns": [
+						{
+							"name": "variable.name.fictionscript",
+							"match": "{.*?}"
+						},
+						{
+							"name": "constant.character.escape",
+							"match": "\\\\n"
+						},
+						{
+							"name": "markup.italic",
+							"match": "."
+						}
+					]
+				}
+			]
+		}
+	},
+	"scopeName": "source.fic"
+}

--- a/fictionsuit-vscode-ext/fictionscript-syntax/vsc-extension-quickstart.md
+++ b/fictionsuit-vscode-ext/fictionscript-syntax/vsc-extension-quickstart.md
@@ -1,0 +1,29 @@
+# Welcome to your VS Code Extension
+
+## What's in the folder
+
+* This folder contains all of the files necessary for your extension.
+* `package.json` - this is the manifest file in which you declare your language support and define the location of the grammar file that has been copied into your extension.
+* `syntaxes/fictionscript.tmLanguage.json` - this is the Text mate grammar file that is used for tokenization.
+* `language-configuration.json` - this is the language configuration, defining the tokens that are used for comments and brackets.
+
+## Get up and running straight away
+
+* Make sure the language configuration settings in `language-configuration.json` are accurate.
+* Press `F5` to open a new window with your extension loaded.
+* Create a new file with a file name suffix matching your language.
+* Verify that syntax highlighting works and that the language configuration settings are working.
+
+## Make changes
+
+* You can relaunch the extension from the debug toolbar after making changes to the files listed above.
+* You can also reload (`Ctrl+R` or `Cmd+R` on Mac) the VS Code window with your extension to load your changes.
+
+## Add more language features
+
+* To add features such as IntelliSense, hovers and validators check out the VS Code extenders documentation at https://code.visualstudio.com/docs
+
+## Install your extension
+
+* To start using your extension with Visual Studio Code copy it into the `<user home>/.vscode/extensions` folder and restart Code.
+* To share your extension with the world, read on https://code.visualstudio.com/docs about publishing an extension.

--- a/fictionsuit-vscode-ext/reinstall
+++ b/fictionsuit-vscode-ext/reinstall
@@ -1,0 +1,2 @@
+rm -rf ~/.vscode/extensions/fictionscript-syntax/
+cp -r . ~/.vscode/extensions/

--- a/fictionsuit/api_wrap/openai.py
+++ b/fictionsuit/api_wrap/openai.py
@@ -30,6 +30,9 @@ class ChatInstance:
         self.history = []
         self.name = name
 
+    def inspect(self):
+        return f'ChatInstance **{self.name}**\nUsing model "{self.model}"\nMax {self.max_tokens} tokens per response\nTemperature = {self.temperature}\nTop P = {self.top_p}\n\nHistory: {len(self.history)} messages (try `chat dump {self.name}` for full history)'
+
     def __str__(self):
         return f"ChatInstance {self.name}"
 

--- a/fictionsuit/commands/__init__.py
+++ b/fictionsuit/commands/__init__.py
@@ -6,11 +6,12 @@ from .command_group import (
     CommandNotFound,
     CommandReply,
     CommandResult,
-    auto_reply,
     command_split,
     multi_command,
     slow_command,
 )
 from .debug import Debug
+from .discord_only import DiscordOnly
 from .research import Research
 from .scripting import Scripting
+from .text import Text

--- a/fictionsuit/commands/chat.py
+++ b/fictionsuit/commands/chat.py
@@ -188,9 +188,8 @@ class _Chat(CommandGroup):
             split = [x.strip() for x in args.split(maxsplit=1)]
             try:
                 n = int(split[0][1:])
-                if (
-                    len(split) < 2
-                ):  # if "xN" is all that's provided, we have to assume that's the name of the chat instance
+                # if "xN" is all that's provided, we have to assume that's the name of the chat instance
+                if len(split) < 2:
                     n = 1
                     args = split[0]
                 else:
@@ -206,6 +205,8 @@ class _Chat(CommandGroup):
             result = await self.cmd_user(message, f"{split[0]}: {split[1]}")
             if type(result) is CommandFailure:
                 return CommandFailure(f"cmd_user failed:\n{result}")
+
+            args = split[0].rstrip()
 
         scope = self.parent._get_scope()
         if args not in scope:

--- a/fictionsuit/commands/command_group.py
+++ b/fictionsuit/commands/command_group.py
@@ -40,16 +40,9 @@ def slow_command(command):
     return command
 
 
-def auto_reply(command):
-    """Wraps a command the returns `str | None`, causing the command to reply automatically with the returned string."""
-
-    async def _command(s, m, a):
-        result = await command(s, m, a)
-        return CommandReply(result) if type(result) is str else result
-
-    _command.__doc__ = command.__doc__
-    _command.__name__ = command.__name__
-    return _command
+def parse_args_as_expression(command):
+    command.requests_expression = True
+    return command
 
 
 def default_on_none(default):
@@ -94,7 +87,7 @@ class CommandGroup:
 
     The rest of the function name is the command name.
     "message" is the UserMessage that contains the command
-    "args" is everything in the message after the command prefix and command name
+    "args" is everything in the message after the command name
     A handler's name must not contain any upper-case characters. Usage will not be case-sensitive.
     """
 
@@ -184,21 +177,18 @@ class CommandGroup:
 
 
 # TODO: Unit testing
-def command_split(content: str, prefix: str) -> tuple[str, str]:
-    """given a string that starts with the command prefix,
-    returns the command and its arguments as a tuple.
+def command_split(content: str) -> tuple[str, str]:
+    """given a string containing a command, returns the command and its arguments as a tuple.
 
     If there is no command, the command will be None
     If there are no arguments, the arguments will be an empty string.
-
-    **It is the caller's responsibility to ensure that the string starts with the prefix.**
     """
-    after_prefix = content[len(prefix) :].strip()
+    content = content.strip()
 
-    if after_prefix == "":
+    if content == "":
         return (None, "")  # No command
 
-    split_content = after_prefix.split(maxsplit=1)
+    split_content = [x.strip() for x in content.split(maxsplit=1)]
 
     cmd = split_content[0]
 

--- a/fictionsuit/commands/command_group.py
+++ b/fictionsuit/commands/command_group.py
@@ -134,7 +134,7 @@ class CommandGroup:
     async def cmd_cmds(self, message: UserMessage, args: str) -> str | None:
         """`cmds` - print out a list of all available commands"""
         response = f"**__{self.__class__.__name__}__**\n  > "
-        response += "\n  > ".join(self.get_all_commands())
+        response += "\n  > ".join(self.get_command_names())
         return response
 
     @default_on_none(PartialReply(""))
@@ -146,7 +146,7 @@ class CommandGroup:
         `help` - with no command, acts as an alias for `cmds`"""
         if args == "":
             response = f"**__{self.__class__.__name__}__**\n  > "
-            response += "\n  > ".join(self.get_all_commands())
+            response += "\n  > ".join(self.get_command_names())
             return response
 
         command = args.split(maxsplit=1)[0]
@@ -172,8 +172,15 @@ class CommandGroup:
         cmds = [x for x in self.__class__.__dict__ if x.startswith("cmd_")]
         return [x[4:] for x in cmds if hasattr(self.__class__.__dict__[x], "is_slow")]
 
-    def get_all_commands(self) -> list[str]:
+    def get_command_names(self) -> list[str]:
         return [x[4:] for x in self.__class__.__dict__ if x.startswith("cmd_")]
+
+    def get_commands(self) -> dict[str, Callable]:
+        return {
+            x[4:]: self.__class__.__dict__[x]
+            for x in self.__class__.__dict__
+            if x.startswith("cmd_")
+        }
 
 
 # TODO: Unit testing

--- a/fictionsuit/commands/debug.py
+++ b/fictionsuit/commands/debug.py
@@ -4,11 +4,10 @@ import tiktoken
 
 from .. import config
 from ..core.user_message import UserMessage
-from .command_group import CommandGroup, auto_reply
+from .command_group import CommandGroup
 
 
 class Debug(CommandGroup):
-    @auto_reply
     async def cmd_ping(self, message: UserMessage, args: str) -> str:
         """`Returns the one-way latency from the user to the bot"""
         timestamp = await message.get_timestamp()
@@ -17,7 +16,6 @@ class Debug(CommandGroup):
         response = f"Pong! Latency {latency} ms"
         return response
 
-    @auto_reply
     async def cmd_lorem(self, message: UserMessage, args: str) -> str:
         """Returns a few paragraphs of lorem ipsum"""
         return "\n".join(
@@ -47,7 +45,6 @@ class Debug(CommandGroup):
         time.sleep(1)
         await message.undo_react()
 
-    @auto_reply
     async def cmd_echo(self, message: UserMessage, args: str) -> str:
         """Repeats back the arguments."""
         return args

--- a/fictionsuit/commands/discord_only.py
+++ b/fictionsuit/commands/discord_only.py
@@ -1,0 +1,15 @@
+from ..core.user_message import UserMessage
+from .command_group import CommandFailure, CommandGroup
+
+
+class DiscordOnly(CommandGroup):
+    """Commands that are only available in the Discord server."""
+
+    async def cmd_discord_nickname(self, message: UserMessage, args: str):
+        """Set the bot's nickname in the current server."""
+        if not hasattr(message, "set_nickname"):
+            return CommandFailure("This command is only available on Discord.")
+        try:
+            await message.set_nickname(args)
+        except Exception as e:
+            return CommandFailure(f"Failed to set nickname: {e}")

--- a/fictionsuit/commands/research.py
+++ b/fictionsuit/commands/research.py
@@ -1,27 +1,26 @@
-from ..core.user_message import UserMessage
 from .. import config
-from .command_group import CommandGroup, auto_reply
-from ..core.core import summarize, scrape_link
-from ..db.supa_tools import (
-    upload_article,
-    upload_article_embeddings,
-    get_articles,
-    delete_article,
-)
+from ..core.core import scrape_link, summarize
+from ..core.user_message import UserMessage
 from ..db.search import (
-    embed_query,
     create_mappings,
-    get_cosine_similarity,
+    embed_query,
     get_article_blurbs,
+    get_cosine_similarity,
     set_cache_needs_update,
 )
+from ..db.supa_tools import (
+    delete_article,
+    get_articles,
+    upload_article,
+    upload_article_embeddings,
+)
+from .command_group import CommandGroup
 
 
 class Research(CommandGroup):
-    @auto_reply
     async def cmd_read(self, message: UserMessage, args: str) -> str:
         """**__Read__**
-        `prefix read` - returns a summary of the linked article, uploads, and embeds
+        `read` - returns a summary of the linked article, uploads, and embeds
         """
         article = await scrape_link(args)
         # should prepend the title, author, metadata, date, url to the cleaned_text of the file too
@@ -34,18 +33,16 @@ class Research(CommandGroup):
             await message.reply(f"Article uploaded to Supabase with ID: {article_id}")
         return summary
 
-    @auto_reply
     async def cmd_scrape(self, message: UserMessage, args: str):
         """**__Scrape__**
-        `prefix scrape` - returns scraped URL
+        `scrape` - returns scraped URL
         """
         article = await scrape_link(args)
         return article.cleaned_text
 
-    @auto_reply
     async def cmd_list_articles(self, message, args):
         """**__Recall__**
-        `prefix list_articles` - returns a list of all articles in the database
+        `list_articles` - returns a list of all articles in the database
         """
         articles = await get_articles()
         ar_list = ""
@@ -55,17 +52,16 @@ class Research(CommandGroup):
 
     async def cmd_delete_article(self, message, args):
         """**__Delete__**
-        `prefix delete_article` - deletes an article from the database
+        `delete_article` - deletes an article from the database
         """
         article_id = args
         await delete_article(article_id)
         set_cache_needs_update()
         await message.reply(f"Article <{article_id}> deleted from database")
 
-    @auto_reply
     async def cmd_search(self, message, args):
         """**__Search__**
-        `prefix search` - searches for similar articles in the database"""
+        `search` - searches for similar articles in the database"""
         query = args
         embeddings_list, id_mappings = create_mappings()
         query_embedding = await embed_query(query)

--- a/fictionsuit/commands/text.py
+++ b/fictionsuit/commands/text.py
@@ -1,0 +1,92 @@
+import re
+
+from ..core.user_message import UserMessage
+from .command_group import CommandGroup
+
+
+class Text(CommandGroup):
+    """Text manipulation & interpretation helper methods."""
+
+    _cleaner = re.compile("[^a-zA-Z]")
+
+    # Tetralemma
+    def _which(self, a: str, b: str, text: str) -> tuple[bool, str]:
+        low = Text._cleaner.sub(" ", text.lower()).split()
+        is_a = a.lower() in low
+        is_b = b.lower() in low
+        if is_a and not is_b:
+            return (True, a)
+        if is_b and not is_a:
+            return (True, b)
+        if is_a:  # both
+            return (False, "both")
+        # neither
+        return (False, "neither")
+
+    def _is_x(self, a: str, b: str, x: str, text: str) -> bool:
+        (classical, result) = self._which(a, b, text)
+        return result == x if classical else result == "both"
+
+    def _is_not_x(self, a: str, b: str, x: str, text: str) -> bool:
+        (classical, result) = self._which(a, b, text)
+        return result != x if classical else result == "neither"
+
+    def _is_just_x(self, a: str, b: str, x: str, text: str) -> bool:
+        (classical, result) = self._which(a, b, text)
+        return result == x if classical else False
+
+    def _is_not_just_x(self, a: str, b: str, x: str, text: str) -> bool:
+        (classical, result) = self._which(a, b, text)
+        return result != x if classical else True
+
+    # One must be careful when trying to extract classical truth values from the answers of a language model
+
+    async def cmd_is_true(self, message: UserMessage, args: str) -> bool:
+        return self._is_x("true", "false", "true", args)
+
+    async def cmd_just_true(self, message: UserMessage, args: str) -> bool:
+        return self._is_just_x("true", "false", "true", args)
+
+    async def cmd_is_false(self, message: UserMessage, args: str) -> bool:
+        return self._is_x("true", "false", "false", args)
+
+    async def cmd_just_false(self, message: UserMessage, args: str) -> bool:
+        return self._is_just_x("true", "false", "false", args)
+
+    async def cmd_not_true(self, message: UserMessage, args: str) -> bool:
+        return self._is_not_x("true", "false", "true", args)
+
+    async def cmd_not_just_true(self, message: UserMessage, args: str) -> bool:
+        return self._is_not_just_x("true", "false", "true", args)
+
+    async def cmd_not_false(self, message: UserMessage, args: str) -> bool:
+        return self._is_not_x("true", "false", "false", args)
+
+    async def cmd_not_just_false(self, message: UserMessage, args: str) -> bool:
+        return self._is_not_just_x("true", "false", "false", args)
+
+    # When you just want a simple "yes" or "no"...
+
+    async def cmd_is_yes(self, message: UserMessage, args: str) -> bool:
+        return self._is_x("yes", "no", "yes", args)
+
+    async def cmd_just_yes(self, message: UserMessage, args: str) -> bool:
+        return self._is_just_x("yes", "no", "yes", args)
+
+    async def cmd_is_no(self, message: UserMessage, args: str) -> bool:
+        return self._is_x("yes", "no", "no", args)
+
+    async def cmd_just_no(self, message: UserMessage, args: str) -> bool:
+        return self._is_just_x("yes", "no", "no", args)
+
+    async def cmd_not_yes(self, message: UserMessage, args: str) -> bool:
+        return self._is_not_x("yes", "no", "yes", args)
+
+    async def cmd_not_just_yes(self, message: UserMessage, args: str) -> bool:
+        return self._is_not_just_x("yes", "no", "yes", args)
+
+    async def cmd_not_no(self, message: UserMessage, args: str) -> bool:
+        return self._is_not_x("yes", "no", "no", args)
+
+    async def cmd_not_just_no(self, message: UserMessage, args: str) -> bool:
+        return self._is_not_just_x("yes", "no", "no", args)

--- a/fictionsuit/core/basic_command_system.py
+++ b/fictionsuit/core/basic_command_system.py
@@ -29,7 +29,7 @@ class BasicCommandSystem(System):
         self.respond_on_unrecognized = respond_on_unrecognized
 
         all_commands = [
-            command for group in command_groups for command in group.get_all_commands()
+            command for group in command_groups for command in group.get_command_names()
         ]
 
         # TODO: this doesn't actually work; figure out why
@@ -67,7 +67,7 @@ class BasicCommandSystem(System):
                 if type(content) is CommandFailure:
                     if return_failures:
                         return content
-                    message.reply(
+                    await message.reply(
                         f"Failed in content interceptor of command group {group.__class__.__name__}:\n{content}"
                     )
                     return

--- a/fictionsuit/core/basic_command_system.py
+++ b/fictionsuit/core/basic_command_system.py
@@ -1,14 +1,12 @@
 from typing import Sequence
 
-from ..api_wrap.openai import ChatInstance
-
 from .. import config
+from ..api_wrap.openai import ChatInstance
 from ..commands.command_group import (
     CommandFailure,
     CommandGroup,
     CommandHandled,
     CommandNotFound,
-    CommandReply,
     PartialReply,
     command_split,
 )
@@ -25,12 +23,10 @@ class BasicCommandSystem(System):
         stats_ui: bool = True,
         respond_on_unrecognized: bool = False,
         enable_scripting: bool = False,
-        prefix: str = config.COMMAND_PREFIX,
     ):
         self.command_groups = command_groups
         self.stats_ui = stats_ui
         self.respond_on_unrecognized = respond_on_unrecognized
-        self.prefix = prefix
 
         all_commands = [
             command for group in command_groups for command in group.get_all_commands()
@@ -46,10 +42,10 @@ class BasicCommandSystem(System):
         self.slow_commands = None
 
         if enable_scripting:
-            self.command_groups += [Scripting(self, self.command_groups)]
+            self.command_groups += [Scripting(self.command_groups)]
 
         for group in self.command_groups:
-            group.command_prefix = prefix
+            group.system = self
             group.inspect_other_groups(self.command_groups)
 
     async def enqueue_message(
@@ -57,25 +53,32 @@ class BasicCommandSystem(System):
         message: UserMessage,
         return_failures: bool = False,
         return_returns: bool = False,
+        return_whatever: bool = False,
     ):
         content = message.content
+
+        if return_whatever:
+            return_failures = True
+            return_returns = True
 
         try:
             for group in self.command_groups:
                 content = await group.intercept_content(content)
                 if type(content) is CommandFailure:
-                    return content if return_failures else None
+                    if return_failures:
+                        return content
+                    message.reply(
+                        f"Failed in content interceptor of command group {group.__class__.__name__}:\n{content}"
+                    )
+                    return
         except Exception as e:
             await message.reply(f"Content interceptor threw an exception: {e}")
             content = message.content
 
-        if not message.has_prefix(self.prefix):
-            return  # Not handling non-prefixed messages, for now
-
-        (cmd, args) = command_split(content, self.prefix)
+        (cmd, args) = command_split(content)
 
         if cmd is None:
-            return  # Nothing but a prefix. Nothing to do.
+            return  # Nothing to do.
 
         if self.slow_commands is None:
             self.slow_commands = []
@@ -101,10 +104,9 @@ class BasicCommandSystem(System):
                     await message.react("❌")
                     await message.reply(f'Command "{cmd}" failed:\n{result}')
                     return result if return_failures else None
-                # if type(result) is CommandReply:
-                #     await message.reply(result)
-                #     return
                 if return_returns and cmd == "return":
+                    return result
+                elif return_whatever:
                     return result
                 if type(result) is PartialReply:
                     accumulator = result
@@ -127,12 +129,19 @@ class BasicCommandSystem(System):
             if cmd_is_slow:
                 await message.undo_react("⏳")
             await message.reply(accumulator)
+            if return_whatever:
+                return accumulator
             return
 
         await message.undo_react("⏳")
 
         if self.respond_on_unrecognized:
             await self.direct_chat(message)
+        else:
+            if return_failures:
+                return CommandFailure(f'Command "{cmd}" not recognized.')
+            else:
+                await message.reply(f'Command "{cmd}" not recognized.')
 
     async def direct_chat(self, message: UserMessage):
         if hasattr(message, "discord_message"):

--- a/fictionsuit/core/cli.py
+++ b/fictionsuit/core/cli.py
@@ -3,9 +3,8 @@ import sys
 import time
 from io import TextIOBase
 
-from ..api_wrap.openai import ApiMessages
-
 from .. import config
+from ..api_wrap.openai import ApiMessages
 from .system import System
 from .user_message import UserMessage
 
@@ -20,7 +19,6 @@ class TextIOClient:
         reactions: bool = False,
     ):
         self.system = system
-        self.prefix = system.prefix if hasattr(system, "prefix") else ""
         self.text_in = text_in
         self.text_out = text_out
         self.cli = cli
@@ -35,8 +33,6 @@ class TextIOClient:
         input_indicator = ""
         if self.cli:
             greeting = f"Welcome to Fictionsuit CLI."
-            if self.prefix != "":
-                greeting = f'{greeting} The command prefix is "{self.prefix}"'
             input_indicator = "\n> "
             self.print(f"{greeting}{input_indicator}")
             self.skip_next_newline = True

--- a/fictionsuit/core/cli.py
+++ b/fictionsuit/core/cli.py
@@ -37,8 +37,17 @@ class TextIOClient:
             self.print(f"{greeting}{input_indicator}")
             self.skip_next_newline = True
         try:
+            message_lines = []
             for line in self.text_in:
-                wrap = TextIOMessage(self, line)
+                line = line.rstrip()
+                if line.endswith("--"):
+                    self.text_out.write("--> ")
+                    self.text_out.flush()
+                    message_lines.append(line[:-2])
+                    continue
+                message_lines.append(line)
+                wrap = TextIOMessage(self, "\n".join(message_lines))
+                message_lines = []
                 wrap.no_react = not self.reactions
                 await self.system.enqueue_message(wrap)
                 self.text_out.write(input_indicator)

--- a/fictionsuit/core/fictionscript/__init__.py
+++ b/fictionsuit/core/fictionscript/__init__.py
@@ -1,3 +1,3 @@
 from .fictionscript import FictionScript
-from .script_message import ScriptMessage
 from .scope import Scope
+from .script_message import ExpressionMessage, ScriptLineMessage

--- a/fictionsuit/core/fictionscript/fictionscript.py
+++ b/fictionsuit/core/fictionscript/fictionscript.py
@@ -1,6 +1,6 @@
 class FictionScript:
     def __init__(self, lines, source=None, name=None):
-        self.lines = lines
+        self.lines = [l.rstrip("\n") for l in lines]
         self.source = source
         self.name = name  # TODO: the FictionScript type should be responsible for determining script names from filenames...
 
@@ -18,6 +18,16 @@ class FictionScript:
                     self.args.append(arg_line[4:].split(":=", maxsplit=1)[0].strip())
                 else:
                     self.args.append(arg_line[4:].split("=", maxsplit=1)[0].strip())
+
+    def inspect(self):
+        top_comments = []
+        for line in self.lines:
+            if line.startswith("#"):
+                top_comments.append(line[1:])
+            else:
+                break
+        doc = "\n".join(top_comments)
+        return f"FictionScript **{self.name}**\n```\n{doc}\n```"
 
     def __str__(self):
         return f"FictionScript {self.name}"

--- a/fictionsuit/core/fictionscript/scope.py
+++ b/fictionsuit/core/fictionscript/scope.py
@@ -9,7 +9,7 @@ class Scope:
         self.vars = vars if vars else {}
         if name is None:
             if parent is None:
-                self.name = "| base"
+                self.name = "| (base)"
             else:
                 self.name = f"{parent.name} > anon"
         else:
@@ -19,20 +19,59 @@ class Scope:
                 self.name = f"{parent.name} > {name}"
         self._has_defaulting_args = False
 
+    def recontextualize(self, new_name, new_parent):
+        self.parent = new_parent
+        if new_name is None:
+            if new_parent is None:
+                self.name = "| (base)"
+            else:
+                self.name = f"{new_parent.name} > anon"
+        else:
+            if new_parent is None:
+                self.name = f"| {new_name}"
+            else:
+                self.name = f"{new_parent.name} > {new_name}"
+
+    def inspect(self):
+        if len(self.vars) == 0:
+            return f"{self.name}\n```\nEmpty scope.\n```"
+        longest = max([len(key) for key in self.vars])
+        dump = [
+            f"{' ' * (1 + longest - len(key))}{{{key}}} : {self.vars[key]}"
+            for key in self.vars
+        ]
+        dump_split = []
+        for line in dump:
+            while len(line) > 80:
+                dump_split.append(line[:80])
+                line = f"{' ' * (5 + longest)} {line[80:]}"
+            dump_split.append(line)
+        result = "\n".join(dump_split)
+        return f"Scope {self.name}\n```\n{result}\n```"
+
     def __str__(self):
-        return f"Scope {self.name} >"
+        return f"[Scope] {self.name} >"
 
     def __repr__(self):
-        return f"<Scope {self.name}>"
+        return f"[Scope] {self.name} >"
 
     def move_up(self, k):
         self.parent[k] = self[k]
 
-    def get_vars(self, with_children=True) -> dict:
+    def get_vars(self, with_children=True, visited=None) -> dict:
+        if visited is None:
+            visited = []
+        if self in visited:
+            return {}
         if with_children:
             vars = self.vars
 
-            def get_child_vars(s: Scope, pfx: str):
+            def get_child_vars(s: Scope, pfx: str, visited=None):
+                if visited == None:
+                    visited = []
+                if s in visited:
+                    return {}
+                visited.append(s)
                 nonscopes = {
                     f"{pfx} {var}": s.vars[var]
                     for var in s.vars
@@ -50,17 +89,20 @@ class Scope:
                     scope_vars.update(scopes)
                 for scope_name in scopes:
                     scope_vars.update(
-                        get_child_vars(scopes[scope_name], f"{scope_name} >")
+                        get_child_vars(scopes[scope_name], f"{scope_name} >", visited)
                     )
                 return scope_vars
 
-            vars = {**get_child_vars(self, f"|"), **self.vars}
+            vars = {**get_child_vars(self, f"|", visited), **self.vars}
         else:
             vars = self.vars
 
         # Pull in vars from outer scope, override any collisions
         if self.parent is not None:
-            return {**self.parent.get_vars(with_children=False), **vars}
+            return {
+                **self.parent.get_vars(with_children=False, visited=visited),
+                **vars,
+            }
 
         return vars
 

--- a/fictionsuit/core/fictionscript/scope.py
+++ b/fictionsuit/core/fictionscript/scope.py
@@ -9,12 +9,12 @@ class Scope:
         self.vars = vars if vars else {}
         if name is None:
             if parent is None:
-                self.name = "| (base)"
+                self.name = "(base)"
             else:
                 self.name = f"{parent.name} > anon"
         else:
             if parent is None:
-                self.name = f"| {name}"
+                self.name = f"{name}"
             else:
                 self.name = f"{parent.name} > {name}"
         self._has_defaulting_args = False
@@ -23,12 +23,12 @@ class Scope:
         self.parent = new_parent
         if new_name is None:
             if new_parent is None:
-                self.name = "| (base)"
+                self.name = "(base)"
             else:
                 self.name = f"{new_parent.name} > anon"
         else:
             if new_parent is None:
-                self.name = f"| {new_name}"
+                self.name = f"{new_name}"
             else:
                 self.name = f"{new_parent.name} > {new_name}"
 
@@ -73,12 +73,12 @@ class Scope:
                     return {}
                 visited.append(s)
                 nonscopes = {
-                    f"{pfx} {var}": s.vars[var]
+                    f"{pfx} {var}".lstrip(): s.vars[var]
                     for var in s.vars
                     if type(s.vars[var]) is not Scope
                 }
                 scopes = {
-                    f"{pfx} {var}": s.vars[var]
+                    f"{pfx} {var}".lstrip(): s.vars[var]
                     for var in s.vars
                     if type(s.vars[var]) is Scope
                 }
@@ -93,7 +93,7 @@ class Scope:
                     )
                 return scope_vars
 
-            vars = {**get_child_vars(self, f"|", visited), **self.vars}
+            vars = {**get_child_vars(self, "", visited), **self.vars}
         else:
             vars = self.vars
 

--- a/fictionsuit/core/fictionscript/script_message.py
+++ b/fictionsuit/core/fictionscript/script_message.py
@@ -2,9 +2,34 @@ from ...api_wrap.openai import ApiMessages
 from ...core.user_message import UserMessage
 
 
-class ScriptMessage(UserMessage):
+class ScriptLineMessage(UserMessage):
     def __init__(self, content: str, filename: str, invoker: UserMessage):
         super().__init__(content, f"script: {filename}")
+        self.invoker = invoker
+        self.disable_interactions = invoker.disable_interactions
+
+    async def _send(self, message_content: str) -> bool:
+        return await self.invoker._send(message_content)
+
+    async def _reply(self, reply_content: str) -> bool:
+        return await self.invoker._reply(reply_content)
+
+    async def _react(self, reaction: str | None) -> bool:
+        return await self.invoker._react(reaction)
+
+    async def _undo_react(self, reaction: str | None) -> bool:
+        return await self.invoker._undo_react(reaction)
+
+    async def _get_timestamp(self) -> float:
+        return await self.invoker._get_timestamp()
+
+    async def _retrieve_history(self) -> ApiMessages:
+        return await self.invoker._retrieve_history()
+
+
+class ExpressionMessage(UserMessage):
+    def __init__(self, content: str, context: str, invoker: UserMessage):
+        super().__init__(content, f"expression: {context}")
         self.invoker = invoker
         self.disable_interactions = invoker.disable_interactions
 

--- a/fictionsuit/core/system.py
+++ b/fictionsuit/core/system.py
@@ -12,6 +12,7 @@ class System(ABC):
         message: UserMessage,
         return_failures: bool = False,
         return_returns: bool = False,
+        return_whatever: bool = False,
     ):
         """Called whenever a new user message arrives."""
         pass

--- a/fictionsuit/core/user_message.py
+++ b/fictionsuit/core/user_message.py
@@ -15,9 +15,6 @@ class UserMessage(ABC):
         self.disable_interactions = False
         self.no_react = False
 
-    def has_prefix(self, prefix: str) -> bool:
-        return self.content.lower().startswith(prefix.lower())
-
     @abstractmethod
     async def _get_timestamp(self) -> float:
         pass

--- a/fictionsuit/fic/auto_face.fic
+++ b/fictionsuit/fic/auto_face.fic
@@ -1,9 +1,13 @@
+# Given a character name and a simple starting description, generates:
+# {description} - A more detailed description of the character
+# {style} - A description of the character's distinctive writing style
+# {goals} - An explanation of the character's motivation or purpose
+
 # Define a variable that must be provided by the user
 arg name
 # Define a variable that will use a default value if not provided by the user
 # ":=" is shorthand for "= echo" here
 arg initial description := All I've really decided so far is the name of the character.
-
 
 # Load in a helper method from another file
 # $FIC is shorthand for ".fictionsuit/fic"
@@ -32,13 +36,6 @@ load_fic $FIC/face/face_aspect.fic
 
 | goals = fic face aspect: {prompt}, the character's goals and desires, The character seeks to, Sauron, {sauron goals}
 
-
-# Create a scope called "-", pack the vars into it, and return it.
-# TODO: make a shorthand for this, like:
-# return name, description, style, goals
-scope -
-| - > name = | name
-| - > description = | description
-| - > style = | style
-| - > goals = | goals
-return -
+# Pack the variables into a new scope and return the scope
+# TODO: syntactic sugar for pack? (e.g. "return [name, description, style, goals]")
+return pack name, description, style, goals

--- a/fictionsuit/fic/auto_face.fic
+++ b/fictionsuit/fic/auto_face.fic
@@ -37,5 +37,5 @@ load_fic $FIC/face/face_aspect.fic
 | goals = fic face aspect: {prompt}, the character's goals and desires, The character seeks to, Sauron, {sauron goals}
 
 # Pack the variables into a new scope and return the scope
-# TODO: syntactic sugar for pack? (e.g. "return [name, description, style, goals]")
+# TODO: syntactic sugar for pack? (e.g. "return |: name, description, style, goals")
 return pack name, description, style, goals

--- a/fictionsuit/fic/face/face_aspect.fic
+++ b/fictionsuit/fic/face/face_aspect.fic
@@ -15,6 +15,6 @@ chat temp 1.2 helper
 
 <system @ helper> Complete the sentence: {context}
 
-| result = chat continue helper
+| result = <helper++>
 
 return | result

--- a/fictionsuit/fic/face/face_aspect.fic
+++ b/fictionsuit/fic/face/face_aspect.fic
@@ -17,4 +17,4 @@ chat temp 1.2 helper
 
 | result = chat continue helper
 
-return result
+return | result

--- a/fictionsuit/fic/first_person.fic
+++ b/fictionsuit/fic/first_person.fic
@@ -1,0 +1,18 @@
+# Given some text, return the same text, rewritten to be in the first person
+# from the perspective of "author".
+
+args author, text
+
+chat new editor
+chat temp 1.2 editor
+
+<system @ editor> The user will provide text, which will be rewritten to be in the first person perspective and the present tense.
+<assistant @ editor> The user will give me a piece of text about Albert Einstein. I will rewrite the text to be in the first person from the perspective of Albert Einstein. I will ensure that the text is written in first person, present tense.
+<user @ editor> Albert Einstein was a theoretical physicist who worked on generalizing of Newton's laws of physics, with contributions such as special and general relativity, the matter-energy equivalence formula (E=mc2), and work on quantum mechanics; and who won a Nobel Prize for his contributions to theoretical physics.
+<assistant @ editor> I am a theoretical physicist who has worked on generalizing Newton's laws of physics, with contributions such as special and general relativity, the matter-energy equivalence formula (E=mc2), and quantum mechanics. I have won a Nobel Prize for my contributions to theoretical physics.
+
+<system @ editor> The user will provide text, which will be rewritten to be in the first person perspective and the present tense.
+<assistant @ editor> You will give me a piece of text about {author}. I will rewrite the text to be in the first person from the perspective of {author}. I will ensure that the text is written in first person, present tense.
+<user @ editor> {text}
+
+return <editor++>

--- a/fictionsuit/fic/query.fic
+++ b/fictionsuit/fic/query.fic
@@ -9,4 +9,4 @@ chat new c
 <assistant @ c> I am ready to answer your question about the text.
 <user @ c> {query}
 
-return chat continue c
+return <c++>

--- a/fictionsuit/fic/query.fic
+++ b/fictionsuit/fic/query.fic
@@ -1,10 +1,12 @@
+# Asks a new ChatInstance a question about some text.
+
 args text, query
 
 chat new c
 
-<system @ c> The user will ask you a question about this text, and you will answer briefly and accurately:\n{text}
-<user   @ c> {query}
+<system @ c> I answer questions about segments of text.
+<c> Here is some text:\n{text}
+<assistant @ c> I am ready to answer your question about the text.
+<user @ c> {query}
 
-| response = chat continue c
-
-return response
+return chat continue c

--- a/fictionsuit/fic/yes_or_no.fic
+++ b/fictionsuit/fic/yes_or_no.fic
@@ -16,7 +16,7 @@ chat limit 5 c
 <c> {query}
 
 # Get the response, check if it is just a yes or a no
-| response = chat continue c
+| response = <c++>
 | y = just_yes {response}
 | n = just_no {response}
 

--- a/fictionsuit/fic/yes_or_no.fic
+++ b/fictionsuit/fic/yes_or_no.fic
@@ -1,0 +1,32 @@
+# Given a text and a yes-or-no question about the text, attempts to get ChatGPT to answer
+# the question with a simple "yes" or "no".
+
+# Define arguments
+args text, query
+
+# Instantiate a new chat instance and configure it
+chat new c
+chat temp 1.2 c
+chat limit 5 c
+
+# Fill in the prompt to get the instance to answer the question
+<system @ c> I answer yes-or-no questions about segments of text.
+<user @ c> Here is some text: {text}
+<assistant @ c> I am ready to answer your yes-or-no question about the text.
+<c> {query}
+
+# Get the response, check if it is just a yes or a no
+| response = chat continue c
+| y = just_yes {response}
+| n = just_no {response}
+
+# If so, return it
+if just_yes {response} then | result := yes
+if just_no {response} then | result := no
+
+# | foo > bar > baz
+
+# Fail otherwise
+if fails | result then fail ChatGPT failed to answer your question with a simple "yes" or "no". Here's its response:\n{response} 
+
+return | result

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 import discord
 
 from fictionsuit.api_wrap import DiscordBotClient
-from fictionsuit.commands import Chat, Debug, Research
+from fictionsuit.commands import Chat, Debug, DiscordOnly, Research, Text
 from fictionsuit.core import BasicCommandSystem
 
 
@@ -10,7 +10,7 @@ def main():
     intents.message_content = True
     intents.members = True
 
-    command_groups = [Debug(), Research(), Chat()]
+    command_groups = [Debug(), Research(), Chat(), Text(), DiscordOnly()]
 
     system = BasicCommandSystem(
         command_groups,


### PR DESCRIPTION
- Partial syntax highlighting for .fic files in VSCode
- "Command prefix" is now a discord-specific idea, no longer reaching its horrid tentacles all throughout the command parsing code
- Discord nicknames can now be changed
- Scopes, chatinstances, and scripts can now be "inspected" with the ? operator
- @auto_reply removed -- everything is auto_reply, automatically, now
- Added several commands for parsing classical boolean values out of gpt-generated text that might contain nonsense like "yes and no" or "i'm afraid i can't answer that question for you"
- Made it a bit harder to break the scoping system with recursive scopes
- "return" now evaluates general expressions instead of just returning variables
- Additional scripting commands:
- - inspect: calls the inspect method of the object, if it has one
- - if: lets you branch
- - fail: returns a CommandFailure, with args as the message
- - silently: executes its args as an expression and does not fail if the expression fails. returns nothing, no matter what
- - retrieve can now pull items out of lists, by writing "| index @ scope > variable" to pull the item at index "index" out of "| scope > variable"
- - fails: Evaluates its args as an expression; returns True if the expression returns a CommandFailure, False otherwise.