### PR TITLE
setup docker container and fly hosting

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+# flyctl launch added from .gitignore
+**/.env
+**/disco
+**/__pycache__
+**/documents/**/*
+fly.toml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.10
+
+COPY pyproject.toml /app/
+RUN apt-get update && \
+    apt-get install -y build-essential && \
+    pip install poetry
+
+RUN cd /app && poetry config virtualenvs.create false && poetry install --no-dev
+COPY . /app
+
+WORKDIR /app
+CMD ["poetry", "run", "python", "main.py"]

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,12 @@
+# fly.toml file generated for fictionsuit on 2023-03-30T07:58:16-06:00
+
+app = "fictionsuit"
+kill_signal = "SIGINT"
+kill_timeout = 5
+primary_region = "den"
+processes = []
+
+[env]
+
+[experimental]
+  auto_rollback = true


### PR DESCRIPTION
This just adds the Dockerfile and basic fly.toml so you can build and deploy remotely. Berduck is running on a 512MB RAM free instance right not -- on 256 he OOMed from using FAISS